### PR TITLE
Improve the local network detection

### DIFF
--- a/src/server/proxy-service.ts
+++ b/src/server/proxy-service.ts
@@ -25,7 +25,8 @@ export class ProxyService {
 
     if (
       ipAddress === 'unknown' ||
-      ipAddress === '127.0.0.1' ||
+      ipAddress.includes('127.0.0.1') ||
+      ipAddress.includes('localhost') ||
       ipAddress === '::1'
     ) {
       return null;


### PR DESCRIPTION
In some cases, the loopback can be in the form of e.g.  `::ffff:127.0.0.1`, an IPv4-mapped IPv6 address (due to the `::ffff` prefix).