### PR TITLE
Check the reachability of GETGATHER_URL at boot time

### DIFF
--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -42,6 +42,21 @@ app.all('/getgather/*name', async (req, res) => {
   await proxyService.reverseProxy(req, res, path);
 });
 
+try {
+  console.log('Checking GETGATHER_URL:', settings.GETGATHER_URL);
+  const response = await fetch(settings.GETGATHER_URL);
+  if (response.status === 200) {
+    console.log('✓ GETGATHER_URL is reachable');
+  } else {
+    console.warn(`⚠ GETGATHER_URL returned status ${response.status}`);
+  }
+} catch (error) {
+  console.error(
+    '✗ GETGATHER_URL is not reachable:',
+    error instanceof Error ? error.message : String(error)
+  );
+}
+
 if (settings.NODE_ENV === 'development') {
   ViteExpress.listen(app, 3000, () =>
     console.log('Server is listening on port http://localhost:3000')


### PR DESCRIPTION
To verify, just launch as usual `npm run dev`:


```
[nodemon] starting `tsx src/server/main.ts`
Checking GETGATHER_URL: http://localhost:8000
✓ GETGATHER_URL is reachable
Server is listening on port http://localhost:3000
```